### PR TITLE
Add an additional callback when the plugin stops to remove the delta …

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,12 +178,20 @@ module.exports = function(app) {
     server.on('ready', onReady);
 
     function onReady() {
-      ad = mdns.createAdvertisement(mdns.tcp('mqtt'), options.port);
-      ad.start();
+      //Make this optional - Creates issues in some container environments
+      try {
+        ad = mdns.createAdvertisement(mdns.tcp('mqtt'), options.port);
+        ad.start();
+      } 
+      catch (ex) {
+        console.log('Could not start mDNS:' + ex);
+      }
       console.log(
         'Mosca MQTT server is up and running on port ' + options.port
       );
       onStop.push(_ => { server.close() });
+      //When the plugin stops, we should stop the listener also
+      onStop.push(_ => { app.signalk.removeListener('delta', publishLocalDelta) });
     }
   }
 


### PR DESCRIPTION
…listener. Fixes #4

Also wrapped mDNS service registration in a try catch block so that the local server can still startup if mDNS fails