### PR TITLE
Proposed changes to the MQTT gateway plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,6 @@ module.exports = function(app) {
   };
   var server
 
-  var bunyan = require('bunyan');
-  var log = bunyan.createLogger({name: 'mosca'});
 
   plugin.id = id;
   plugin.name = 'Signal K - MQTT Gateway';
@@ -44,11 +42,6 @@ module.exports = function(app) {
         type: 'boolean',
         title: 'Run local server (publish all deltas there in individual topics based on SK path and convert all data published in them by other clients to SK deltas)',
         default: false,
-      },
-      localServerMosca: {
-        type: 'boolean',
-        tutle: 'Runs an embedded local Mosca server or assumes a third party one is running',
-        default: true,
       },
       port: {
         type: 'number',
@@ -111,7 +104,7 @@ module.exports = function(app) {
     plugin.onStop = [];
 
 
-    if (options.runLocalServer || !options.localServerMosca) {
+    if (options.runLocalServer) {
       startLocalServer(options, plugin.onStop);
     }
     if (options.sendToRemote) {


### PR DESCRIPTION
Hi Teppo,

The following changes are proposed: 

1. Changed publishing logic so that topic namespace is expanded if the value of a signalk path is not String or Number but a JSON object.

I understand you have some reservations on this because lat / lon for example only make sense together. However for consistency we should have the same type of values on all topics and be compact over the wire. The topic name provides the context of the value in the payload and an MQTT subscriber can subscribe to as many or as few topics as required, potentially using wildcard topic strings.

 2. Ensured that MQTT payload values are always published as a String and not a Number which makes Mosca fail to stream it to potentially existing subscriber connections. 

This had me going for a while.. When you publish a message with a payload of String or Number but have no active subscribers everything is fine. If you have any subscriptions though they get disconnected each time an MQTT message with a Number as a payload is streamed to them with the following stack: 


    TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type number
    at Function.byteLength (buffer.js:514:11)
    at publish (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/mqtt-packet/generate.js:238:22)
    at generate (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/mqtt-packet/generate.js:15:14)
    at DestroyableTransform.process [as _transform] (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/mqtt-connection/lib/generateStream.js:13:16)
    at DestroyableTransform.Transform._read (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/mqtt-connection/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/mqtt-connection/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/mqtt-connection/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/mqtt-connection/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/mqtt-connection/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at Connection.callWrite3Args [as _callWrite] (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/reduplexer/index.js:50:25)
    at Connection.write [as _write] (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/reduplexer/index.js:147:17)
    at doWrite (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/reduplexer/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/reduplexer/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at Connection.Writable.write (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/reduplexer/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at Connection.(anonymous function) [as publish] (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/mqtt-connection/connection.js:64:12)
    at /Users/krital/dev/signalk-server-node/node_modules/mosca/lib/client.js:200:23
    at Server.authorizeForward (/Users/krital/dev/signalk-server-node/node_modules/mosca/lib/server.js:472:3)
    at doForward (/Users/krital/dev/signalk-server-node/node_modules/mosca/lib/client.js:190:17)
    at Client.forward (/Users/krital/dev/signalk-server-node/node_modules/mosca/lib/client.js:268:9)
    at Array.handler (/Users/krital/dev/signalk-server-node/node_modules/mosca/lib/client.js:443:10)
    at TrieAscoltatore.publish (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/ascoltatori/lib/trie_ascoltatore.js:54:11)
    at TrieAscoltatore.newPublish (/Users/krital/dev/signalk-server-node/node_modules/mosca/node_modules/ascoltatori/lib/abstract_ascoltatore.js:144:20)

Not sure if this is by design or a Mosca bug but as we are several versions behind current perhaps we should try and update first before sending them a PR.

3. When mapping SignalK paths to MQTT topics, also convert : characters in AIS data

When receiving a delta with AIS data and try to convert the path to an MQTT topic, the : character is not allowed and causes errors / disconnections. We are now also converting that to the MQTT topic name delimiter /
