### PR TITLE
fix: guard against undefined values

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,8 +202,8 @@ module.exports = function(app) {
       (delta.context === app.selfContext
         ? 'vessels/self'
         : delta.context.replace('.', '/')) + '/';
-    delta.updates.forEach(update => {
-      update.values.forEach(pathValue => {
+    (delta.updates || []).forEach(update => {
+      (update.values || []).forEach(pathValue => {
         server.publish({
           topic: prefix + pathValue.path.replace(/\./g, '/'),
           payload:


### PR DESCRIPTION
WIth meta deltas it is a common occurrence that there
are deltas without the updates array, so add a guard
against that.