### PR TITLE
Dependency for jsonschema

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "debug": "^2.3.2",
     "mosca": "^2.2.0",
-    "mqtt-nedb-store": "^0.1.0"
+    "mqtt-nedb-store": "^0.1.0",
+    "jsonschema": "1.2.6"
   },
   "optionalDependencies": {
     "mdns": "^2.3.3"


### PR DESCRIPTION
Possible fix for unmaintained Mosca could be set fixed version of jsonschema in package.json. Fixes #18
`"jsonschema": "1.2.6"`
Manually tested, but don't know if possible with npm registry and normal installation from SK Appstore.